### PR TITLE
Fix layout and scrolling issues when going to landscape interface orientation

### DIFF
--- a/CollectionViewShelfLayout/CollectionViewShelfLayout.swift
+++ b/CollectionViewShelfLayout/CollectionViewShelfLayout.swift
@@ -170,6 +170,10 @@ open class CollectionViewShelfLayout: UICollectionViewLayout {
         cellPanningScrollViews.append(panningScrollView)
       }
       
+      for oldPanningScrollView in oldPanningScrollViews {
+        oldPanningScrollView.removeFromSuperview()
+      }
+      
       if let footerView = footerView {
         footerViewLayoutAttributes = CollectionViewShelfLayoutHeaderFooterViewLayoutAttributes(forDecorationViewOfKind: ShelfElementKindCollectionFooter, with: IndexPath(index: 0))
         footerViewLayoutAttributes?.view = footerView
@@ -388,6 +392,9 @@ private class TrackingScrollView: UIScrollView {
     didSet {
       trackingView?.addGestureRecognizer(panGestureRecognizer)
       frame = trackingView?.bounds ?? .zero
+      translatesAutoresizingMaskIntoConstraints = false
+      trackingView?.insertSubview(self, at: 0)
+      alpha = 0
     }
   }
   var trackingFrame: CGRect = CGRect.zero {

--- a/CollectionViewShelfLayout/CollectionViewShelfLayout.swift
+++ b/CollectionViewShelfLayout/CollectionViewShelfLayout.swift
@@ -180,6 +180,13 @@ open class CollectionViewShelfLayout: UICollectionViewLayout {
       }
     }
   }
+    
+  open override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+    guard let collectionView = collectionView else {
+      return true
+    }
+    return collectionView.frame.size != newBounds.size
+  }
   
   open override var collectionViewContentSize: CGSize {
     guard let collectionView = collectionView else {


### PR DESCRIPTION
I've noticed 2 bugs when using this layout in landscape orientation : 
1. The section header/footer bounds are not updated (i.e. they keep their original frame)
    + This has been fixed by overriding `shouldInvalidateLayout`.
2. The panning scrollviews are broken (you must scroll up/down to actually scroll left/right)
    + This has been fixed by adding/removing scrollviews to the collection view. The scrollviews are hidden (alpha = 0). This makes sure scrollviews work in any interface orientation.
